### PR TITLE
fix: crate-type must be cdylib to compile to wasm32-unknown-unknown

### DIFF
--- a/original/Cargo.toml
+++ b/original/Cargo.toml
@@ -13,3 +13,8 @@ web-sys = {version="0.3.63", features = ["HtmlSelectElement"]}
 wasm-logger = "0.2.0"
 wasm-bindgen = "0.2.86"
 dpp = { git="https://github.com/pauldelucia/platform.git", package="dpp", default-features = false, features = ["cbor"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "datacontractcreator"
+path = "src/main.rs"


### PR DESCRIPTION
This PR follows the recommended action following this build error:

```
    Finished release [optimized] target(s) in 2m 06s
  Installing /home/runner/.cargo/bin/wasm-pack
   Installed package `wasm-pack v0.12.0` (executable `wasm-pack`)
Error: crate-type must be cdylib to compile to wasm32-unknown-unknown. Add the following to your Cargo.toml file:

[lib]
crate-type = ["cdylib", "rlib"]
Caused by: crate-type must be cdylib to compile to wasm32-unknown-unknown. Add the following to your Cargo.toml file:

[lib]
crate-type = ["cdylib", "rlib"]
Error: Process completed with exit code 1.
```